### PR TITLE
changed inputs of new password

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -58,15 +58,15 @@
                 autofocus: true,
                 input_html: { autocomplete: "id_scan" }%>
     <%= f.input :password,
+                required: false,
+                label: false,
+                placeholder: "New password",
+                input_html: { autocomplete: "new-password" } %>
+    <%= f.input :password_confirmation,
                 hint: "leave it blank if you don't want to change it",
                 required: false,
                 label: false,
-                placeholder: "Password",
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: false,
-                label: false,
-                placeholder: "Confirm password",
+                placeholder: "Confirm new password",
                 input_html: { autocomplete: "new-password" } %>
     <%= f.input :current_password,
                 hint: "we need your current password to confirm your changes",


### PR DESCRIPTION
Changed the hint "leave it blank if you don't want to change it" below "Confirm new password" because it was confusing to know which one ware the new and the current ones.